### PR TITLE
Update stategoutil with basic MPS setup class

### DIFF
--- a/strategoutil.py
+++ b/strategoutil.py
@@ -4,22 +4,40 @@ import shutil
 import os
 import yaml 
 
+
 def get_int_tuples(text):
-    """converts stratego simulation output to list of tuples
-    (int, int)
+    """
+    Convert Stratego simulation output to list of tuples
+    (int, int).
     """
     string_tuples = re.findall(r"\((\d+),(\d+)\)", text)
     int_tuples = [(int(t[0]), int(t[1])) for t in string_tuples]
     return int_tuples
 
+
+def get_initial_states(model_config_file):
+    """
+    Get the names of the variables that will be replaced each
+    step with updated values and their initial states from the
+    supplied configuration file.
+    """
+    result = {}
+    with open(model_config_file, "r") as yamlfile:
+        cfg = yaml.safe_load(yamlfile)
+        for k, v in cfg.items():
+            result.update({k: v})
+    return result
+
+
 def get_duration_action(tuples, MAX_TIME=None):
-    """get tuples (duration, action) from tuples (time, variable) 
-    resulted from simulate quiery 
+    """
+    Get tuples (duration, action) from tuples (time, variable)
+    resulted from simulate query.
     """
     result = []
-    if len(tuples) == 1: # can only happen if always variable == 0
+    if len(tuples) == 1: # Can only happen if always variable == 0.
         result.append((MAX_TIME, 0))
-    elif len(tuples) == 2: # can only hapen of always variable != 0
+    elif len(tuples) == 2: # Can only happen of always variable != 0.
         action = tuples[1][1]
         result.append((MAX_TIME, action))
     else:
@@ -31,32 +49,41 @@ def get_duration_action(tuples, MAX_TIME=None):
 
     return result
 
-def insert_to_modelfile(path, tag, inserted):
-    """Replaces tag in modelfile by the desired text"""
-    with open(path, "r+") as f:
+
+def insert_to_modelfile(model_file, tag, inserted):
+    """
+    Replace tag in model file by the desired text.
+    """
+    with open(model_file, "r+") as f:
         modeltext = f.read()
         text = modeltext.replace(tag, inserted, 1)
         f.seek(0)
         f.write(text)
         f.truncate()
 
+
 def array_to_stratego(arr):
-    """converts python array string to C style array
-    used in UPPAAL Stratego, 
-    NB, does not include ';' in the end!
+    """
+    Convert python array string to C style array
+    used in UPPAAL Stratego.
+    NB, does not include ';' in the end.
     """
     arrstr = str(arr)
     arrstr = str.replace(arrstr, "[", "{", 1)
     arrstr = str.replace(arrstr, "]", "}", 1)
     return arrstr
 
+
 def merge_verifyta_args(cfg_dict):
-    """Concatenates and formats a string of verifyta
-    arguments given by the .yaml configuration file"""
+    """
+    Concatenate and format a string of verifyta
+    arguments given by the .yaml configuration file.
+    """
     args = ""
     for k, v in cfg_dict.items():
         args += " --" + k + " " + str(v)
     return args[1:]
+
 
 def run_stratego(
     modelfile, 
@@ -84,55 +111,92 @@ def run_stratego(
     result = [r.decode("utf-8") for r in result]
     return result
 
+
 class StrategoController:
     """
-    Abstract controller class to interface with UPPAAL Stratego 
-    through python
+    Controller class to interface with UPPAAL Stratego
+    through python.
     """
-    def __init__(self, templatefile, cleanup=True):
-        self.templatefile = templatefile
-        self.simulationfile = templatefile.replace(".xml","_sim.xml")
+    def __init__(self, modeltemplatefile, modelconfigfile, cleanup=True):
+        self.templatefile = modeltemplatefile
+        self.simulationfile = modeltemplatefile.replace(".xml", "_sim.xml")
         self.cleanup = cleanup
+        self.states = get_initial_states(modelconfigfile)
+        self.tagRule = "//TAG_{}"
 
     def init_simfile(self):
         """
         Make a copy of a template file where data of
-        specific variables is inserted
+        specific variables is inserted.
         """
         shutil.copyfile(self.templatefile, self.simulationfile)
 
     def remove_simfile(self):
-        """Clean created temporary files after the simulation is finished
+        """
+        Clean created temporary files after the simulation is finished.
         """
         os.remove(self.simulationfile)       
 
-    def debug_copy(self, debugFilename):
+    def debug_copy(self, debug_file):
         """
-        copy UPPAAL simulationfile.xml file for manual
-        debug in Stratego
+        Copy UPPAAL simulationfile.xml file for manual
+        debug in Stratego.
         """
-        shutil.copyfile(self.simulationfile, debugFilename)
+        shutil.copyfile(self.simulationfile, debug_file)
+
+    def update_state(self, new_values):
+        """
+        Update the state of the MPC controller.
+        """
+        for name, value in new_values.items():
+            self.states.update({name: value})
 
     def insert_state(self):
         """
-        insert  
+        Insert the current state values of the variables at the
+        appropriate position in the simulation *.xml file indicated
+        by the tag rule.
         """
-        pass
+        for name, value in self.states.items():
+            tag = self.tagRule.format(name)
+            insert_to_modelfile(self.simulationfile, tag, str(value))
+
+    def print_var_names(self):
+        """
+        Print the names of the state variables separated by a ','.
+        """
+        separator = ","
+        return separator.join(self.states.keys())
+
+    def print_state(self):
+        """
+        Print the values of the state variables separated by a ','.
+        """
+        separator = ","
+        values_as_string = [str(val) for val in self.states.values()]
+        return separator.join(values_as_string)
+
+    def get_state(self, key):
+        """
+        Get the current value of the provided state.
+        """
+        return self.states.get(key)
 
     def run(self, 
         queryfile="", 
         learning_args={}, 
         verifyta_path="verifyta"):
         """
-        runs verifyta with requested querries and parameters
+        Runs verifyta with requested queries and parameters
         that are either part of the *.xml model file or explicitly
-        specified  
+        specified.
         """
         output = run_stratego(self.simulationfile, queryfile,
             learning_args, verifyta_path)
         if self.cleanup:
             self.remove_simfile()
         return output[0]
+
 
 if __name__ == '__main__':
     pass

--- a/test/test_strategoutil.py
+++ b/test/test_strategoutil.py
@@ -3,11 +3,12 @@ from unittest import mock
 import os
 import strategoutil as sutil
 
+
 class TestUtil(unittest.TestCase):
-    POPEN_KWARGS = {"shell": True, "stdout":-1, "stderr":-1}
+    POPEN_KWARGS = {"shell": True, "stdout": -1, "stderr": -1}
 
     def test_get_int_tuples_given_single_variable_simulate(self):
-        verifyta_output =  """
+        verifyta_output = """
         -- Formula is satisfied.
         phase:
         [0]: (0,0) (4,0) (4,1) (17,1) (17,0) (25,0) (25,1) (36,1)
@@ -82,9 +83,11 @@ class TestUtil(unittest.TestCase):
             "--max-iterations 30 --filter 0")
             mock_Popen.assert_called_with(expected, **self.POPEN_KWARGS)
 
+
 class TestFileInteraction(unittest.TestCase):
     def setUp(self):
-        """build dummy modelfiles
+        """
+        Build dummy model files.
         """
         self.modelfile = "modelfile.xml"
         with open(self.modelfile, "w") as fin:
@@ -96,7 +99,8 @@ class TestFileInteraction(unittest.TestCase):
             """)
 
     def tearDown(self):
-        """remove modelfile
+        """
+        Remove model file.
         """
         os.remove(self.modelfile)
 
@@ -108,8 +112,3 @@ class TestFileInteraction(unittest.TestCase):
         with open(self.modelfile, "r") as fin:
             correct_substitution = "int important_variable_X = 42;" in fin.read()
             self.assertTrue(correct_substitution)
-
-
-
-
-

--- a/test/test_strategoutil.py
+++ b/test/test_strategoutil.py
@@ -5,7 +5,11 @@ import strategoutil as sutil
 
 
 class TestUtil(unittest.TestCase):
-    POPEN_KWARGS = {"shell": True, "stdout": -1, "stderr": -1}
+    INTERACTIVE_BASH = True
+    if INTERACTIVE_BASH:
+        POPEN_KWARGS = {"stdout": -1, "stderr": -1}
+    else:
+        POPEN_KWARGS = {"shell": True, "stdout": -1, "stderr": -1}
 
     def test_get_int_tuples_given_single_variable_simulate(self):
         verifyta_output = """
@@ -57,13 +61,26 @@ class TestUtil(unittest.TestCase):
     def test_run_stratego_model_only(self):
         with mock.patch("strategoutil.subprocess.Popen") as mock_Popen:
             sutil.run_stratego("model.xml", verifyta_path="$HOME/verifyta")
-            expected = "$HOME/verifyta model.xml"
+            if self.INTERACTIVE_BASH:
+                # Below is the expected result with interactive bash enabled.
+                text = "$HOME/verifyta model.xml"
+                expected = (["/bin/bash", "-i", "-c", text])
+            else:
+                # Below is the expected result with Popen default shell.
+                expected = "$HOME/verifyta model.xml"
+
             mock_Popen.assert_called_with(expected, **self.POPEN_KWARGS)
 
     def test_run_stratego_model_and_query(self):
         with mock.patch("strategoutil.subprocess.Popen") as mock_Popen:
             sutil.run_stratego("model.xml", "query.q")
-            expected = "verifyta model.xml query.q"
+            if self.INTERACTIVE_BASH:
+                # Below is the expected result with interactive bash enabled.
+                text = "verifyta model.xml query.q"
+                expected = ["/bin/bash", "-i", "-c", text]
+            else:
+                # Below is the expected result with Popen default shell.
+                expected = "verifyta model.xml query.q"
             mock_Popen.assert_called_with(expected, **self.POPEN_KWARGS)
 
     def test_run_stratego_all_variables(self):
@@ -78,9 +95,18 @@ class TestUtil(unittest.TestCase):
                 "filter": "0"
             }
             sutil.run_stratego("model.xml", "query.q", learning_args, "verifyta")
-            expected = ("verifyta model.xml query.q --learning-method 4 "
-            "--good-runs 100 --total-runs 100 --runs-pr-state 100 --eval-runs 100 " 
-            "--max-iterations 30 --filter 0")
+            if self.INTERACTIVE_BASH:
+                # Below is the expected result with interactive bash enabled.
+                text = ("verifyta model.xml query.q --learning-method 4 "
+                        "--good-runs 100 --total-runs 100 --runs-pr-state 100 "
+                        "--eval-runs 100 --max-iterations 30 --filter 0")
+                expected = ["/bin/bash", "-i", "-c", text]
+
+            else:
+                # Below is the expected result with Popen default shell.
+                expected = ("verifyta model.xml query.q --learning-method 4 "
+                            "--good-runs 100 --total-runs 100 --runs-pr-state 100 "
+                            "--eval-runs 100 --max-iterations 30 --filter 0")
             mock_Popen.assert_called_with(expected, **self.POPEN_KWARGS)
 
 


### PR DESCRIPTION
This pull request will add a new class to the strategoutil module. This class performs a basic model-predictive control scheme where Uppaal Stratego both synthesizes a controller strategy and simulates the real worls as an application of the first step in that strategy.

Previous usage of `StrategoController` will break, as the constructor method signature has been extended.